### PR TITLE
Pagination claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+.idea

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "PAGINATION_SIZE" : 2,
+  "PAGINATION_SIZE" : 10,
   "CLAIM_STATUS": {
     "CLAIMED": "claimed",
     "ACCEPTED":"accepted",

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "PAGINATION_SIZE" : 5,
   "CLAIM_STATUS": {
     "CLAIMED": "claimed",
     "ACCEPTED":"accepted",

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "PAGINATION_SIZE" : 5,
+  "PAGINATION_SIZE" : 2,
   "CLAIM_STATUS": {
     "CLAIMED": "claimed",
     "ACCEPTED":"accepted",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "express-hbs": "^1.0.4",
     "pg": "^6.1.5",
     "pg-hstore": "^2.3.2",
+    "rsvp": "^3.5.0",
     "sequelize": "^3.30.4"
   },
   "name": "boss-backend",

--- a/routes/api.js
+++ b/routes/api.js
@@ -9,10 +9,17 @@ const du = require('./../utils/datautils');
 const route = new Router();
 
 route.get('/claims', (req, res) => {
-    du.getClaims(req.query.status).then(claims => {
-        res.send(claims)
-    })
 
+    const options = {
+        status : req.query.status,
+        page : req.query.page || 1,
+        size : req.query.size || 99999999
+    }
+
+   du.getClaims(options).then(data => {
+            res.send(data.claims)
+    });
+    
 });
 
 route.get('/claims/:id/delete', (req, res) => {

--- a/routes/root.js
+++ b/routes/root.js
@@ -44,6 +44,7 @@ route.get('/claims/view', (req, res) => {
         size : req.query.size || config.PAGINATION_SIZE
     };
 
+    options.page = parseInt(options.page);
 
     du.getClaims(options).then( data => {
         const pagination = [];
@@ -56,6 +57,8 @@ route.get('/claims/view', (req, res) => {
             pagination : pagination,
             isFirstPage : options.page == 1,
             isLastPage : data.lastPage == options.page ,
+            page : options.page ,
+            size : options.size,
             claims: data.claims,
             menu: {claims_view: 'active'}
         })

--- a/routes/root.js
+++ b/routes/root.js
@@ -9,6 +9,7 @@ const config = require('./../config');
 const db = require('./../utils/db');
 const du = require('./../utils/datautils');
 
+
 const route = new Router();
 
 let adminUser = process.env.BOSS_ADMIN || 'theboss';
@@ -36,9 +37,26 @@ route.get('/leaderboard', (req, res) => {
 });
 
 route.get('/claims/view', (req, res) => {
-    du.getClaims(req.query.status).then(claims => {
+
+    const options = {
+        status : req.query.status,
+        page : req.query.page || 1,
+        size : req.query.size || config.PAGINATION_SIZE
+    };
+
+
+    du.getClaims(options).then( data => {
+        const pagination = [];
+        for(var i=1;i<=data.lastPage;i++)
+            pagination.push(`?page=${i}&size=${options.size}`);
+
         res.render('pages/claims/view', {
-            claims: claims,
+            prevPage : options.page-1,
+            nextPage : options.page+1,
+            pagination : pagination,
+            isFirstPage : options.page == 1,
+            isLastPage : data.lastPage == options.page ,
+            claims: data.claims,
             menu: {claims_view: 'active'}
         })
     })

--- a/server.js
+++ b/server.js
@@ -31,6 +31,10 @@ exphbs.registerHelper('equal', function(lvalue, rvalue, options) {
     }
 });
 
+exphbs.registerHelper('add', function (lvalue,rvalue , options) {
+    return lvalue+rvalue;
+})
+
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.raw());

--- a/utils/datautils.js
+++ b/utils/datautils.js
@@ -2,11 +2,25 @@
  * Created by championswimmer on 16/05/17.
  */
 const db = require('./db');
+const RSVP = require('rsvp');
 
-function getClaims(status) {
-    return db.Claim.findAll({
-        status: status
-    })
+function getClaims(options) {
+
+    const offset = (options.page - 1 ) * options.size ;
+    const lastPage = db.Claim.count().then(cnt=>{
+        return Math.ceil( cnt / options.size );
+    });
+     const claims = db.Claim.findAll({
+        limit : options.size,
+        offset : offset,
+        status: options.status
+    });
+
+    return RSVP.hash({
+        lastPage : lastPage,
+        claims : claims
+    });
+    
 }
 
 function getClaimById(claimId) {

--- a/views/pages/claims/view.hbs
+++ b/views/pages/claims/view.hbs
@@ -38,6 +38,16 @@
             </div>
         </div>
     {{/each}}
+
+    <div class="pagination">
+        <div class="ui pagination menu">
+            {{#each pagination as |link index|}}
+                <a class="item" href="{{link}}" >
+                    {{index}}
+                </a>
+            {{/each}}
+        </div>
+    </div>
 </div>
 <style>
     .user.header {

--- a/views/pages/claims/view.hbs
+++ b/views/pages/claims/view.hbs
@@ -40,13 +40,28 @@
     {{/each}}
 
     <div class="pagination">
+
+
         <div class="ui pagination menu">
+            {{#if isFirstPage}}
+                <a class="item disabled"> Prev</a>
+            {{else}}
+                <a class="item" href="?page={{prevPage}}&size={{size}}" >Prev </a>
+            {{/if}}
+
             {{#each pagination as |link index|}}
-                <a class="item" href="{{link}}" >
-                    {{index}}
+                <a class="item  {{#equal (add index 1) ../page}} active  {{/equal}} "  href="{{link}}" >
+                    {{add index 1}}
                 </a>
             {{/each}}
+            {{#if isLastPage}}
+                <a class="item disabled"> Next </a>
+            {{else}}
+                <a class="item" href="?page={{nextPage}}&size={{size}}" >Next </a>
+            {{/if}}
         </div>
+
+
     </div>
 </div>
 <style>


### PR DESCRIPTION
In reference to issue here: https://github.com/coding-blocks/boss-backend/issues/2

It uses queryParams to paginate results and handles at LOT of corner cases as well.

Use `config.json` to configure initial size of pagination.

![rec](https://cloud.githubusercontent.com/assets/8109774/26115655/3dbce9b6-3a7e-11e7-91ff-81ea68c4caf5.gif)
