### PR TITLE
Validate Github username when adding claim

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -147,7 +147,11 @@ route.post('/claims/add', (req, res) => {
             res.send("Error adding claim")
         });    
     }).catch((err)=>{
-       res.render('pages/claims/add', {error : "Enter a valid Github Username"});
+       if(parseInt(err.statusCode) == 404){
+            res.render('pages/claims/add', {error : "Enter a valid Github Username"});
+       }else{
+            res.render('pages/claims/add', {error : JSON.parse(err.error).message});
+       }
     });
 });
 

--- a/views/pages/claims/add.hbs
+++ b/views/pages/claims/add.hbs
@@ -22,3 +22,10 @@
 
     </div>
 </form>
+{{#if error}}
+<div class="ui negative message">
+  <div class="header" align="center">
+    {{error}}
+  </div>
+</p></div>
+{{/if}}


### PR DESCRIPTION
Issue #9 Resolved.

Added github validation when adding claim. 
If the username is not found, an error message is displayed.
![image](https://cloud.githubusercontent.com/assets/9019318/26808178/c3358d46-4a78-11e7-8951-5a6123ac3721.png)


@championswimmer Please review.
